### PR TITLE
Add support for xor and xnor operations

### DIFF
--- a/test/common_test.py
+++ b/test/common_test.py
@@ -126,20 +126,25 @@ class AbstractTests:
 				with self.subTest(self.input_to_name(inbox)):
 					self.run_program(inbox, inbox)
 
-	# Perform tests on a program which should triple each value in the inbox.
-	class TestTriple(TestValidProgram):
+	# Perform tests on a file which should multiply each value in the inbox by a
+	# given factor, then output it.
+	class TestMultiply(TestValidProgram):
+		# Concrete tests should have a 'factor' property
+
 		floor_size = 16
 
-		def test_triple(self):
+		def test_multiply(self):
 			for inbox in [
 				[],
 				[1, 2, 3, 4, 5],
+				[1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89],
 				[2, 3, 5, 7, 11, 13, 17, 23, 29, 31, 37, 41, 43],
-				[1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233],
 				[3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3],
+				[-12, -4, -5, -4, -9, -7, -5, -10, -20, -14, -9],
+				[-10, 0, 0, 0, 0, -9, -21, -9, 5, 0, -14, -2, 0],
 			]:
 				with self.subTest(self.input_to_name(inbox)):
-					self.run_program(inbox, [x * 3 for x in inbox])
+					self.run_program(inbox, [x * self.factor for x in inbox])
 
 	# Run test cases on programs expected to throw an error in the compiler
 	class TestError(unittest.TestCase):

--- a/test/source/misc/const-xor.hc
+++ b/test/source/misc/const-xor.hc
@@ -1,0 +1,20 @@
+// This program tests for static evaluation of the
+// != operator being used as a logical xor.
+
+// The file should read each value from the inbox,
+// and output double the value.
+
+forever
+	x = input
+
+	if (0 == 1) != (0 == 0)
+		x = x * 2
+
+	if (0 == 1) != (1 == 0)
+		x = x * 3
+
+	if (0 == 0) != (0 == 0)
+		x = x * 5
+
+	if (0 == 0) != (1 == 0)
+		output x

--- a/test/source/misc/logical-xnor.hc
+++ b/test/source/misc/logical-xnor.hc
@@ -1,0 +1,14 @@
+// This program tests use of the equality operator
+// == to act as a logical xnor operator.
+
+// This file should read two values at a time from
+// the inbox, and write them to the outbox only if
+// either both or neither are non-negative.
+
+forever
+	x = input
+	y = input
+
+	if y >= 0 == x >= 0
+		output x
+		output y

--- a/test/source/misc/logical-xor.hc
+++ b/test/source/misc/logical-xor.hc
@@ -1,0 +1,14 @@
+// This program tests use of the equality operator
+// != to act as a logical xor operator.
+
+// This file should read two values at a time from
+// the inbox, and write them to the outbox only if
+// exactly one of them is positive.
+
+forever
+	x = input
+	y = input
+
+	if y > 0 != x > 0
+		output x
+		output y

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -281,3 +281,7 @@ class TestLogicalXnor(AbstractTests.TestValidProgram):
 class TestConstXor(AbstractTests.TestMultiply):
 	source_path = "misc/const-xor.hc"
 	factor = 2
+
+class TestConstXnor(AbstractTests.TestMultiply):
+	source_path = "misc/const-xnor.hc"
+	factor = 2

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -260,3 +260,30 @@ class TestLogicalXor(AbstractTests.TestValidProgram):
 			 [            6,  0,   4,   0]),
 			([ 10,   5,   8, 13,  10,   9,  3,  10], []),
 		])
+
+class TestLogicalXnor(AbstractTests.TestValidProgram):
+	source_path = "misc/logical-xnor.hc"
+	floor_size = 16
+
+	# This file tests use of the equals operator as logical xnor.
+	# The file should read pairs of values from the inbox, then output them both
+	# only if either both or neither are non-negative.
+	def test_output(self):
+		self.run_tests([
+			([], []),
+			([  1, -11], []),
+			([ -2,  11,  -7,  7], []),
+			([  3,  -4,   2, 13,  -9, -14], [2, 13, -9, -14]),
+			([-12,  11, -11, -1,  14, -14, -8,   7],
+			 [          -11, -1,                  ]),
+			([ -3,  -9,  13, -3, -13,  10, -4, -21],
+			 [ -3,  -9,                    -4, -21]),
+			([  7,   0,   0,  5,   1,  17,  1, -12],
+			 [  7,   0,   0,  5,   1,  17]),
+			([  0,   0,   6,  0,   4,   0,  3,  10],
+			 [  0,   0,   6,  0,   4,   0,  3,  10]),
+			([ 10,   5,   8, 13,  10,   9,  3,  10],
+			 [ 10,   5,   8, 13,  10,   9,  3,  10]),
+			([  0,   0,  -7,  0,   0,  -3, -5, -11],
+			 [  0,   0,                    -5, -11]),
+		])

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -80,13 +80,15 @@ class TestConstGt(AbstractTests.TestEcho):
 	# Tests constant evaluation of the greater than operator
 	source_path = "misc/const-gt.hc"
 
-class TestConstLe(AbstractTests.TestTriple):
+class TestConstLe(AbstractTests.TestMultiply):
 	# Tests constant evaluation of the less than or equal to operator
 	source_path = "misc/const-le.hc"
+	factor = 3
 
-class TestConstGe(AbstractTests.TestTriple):
+class TestConstGe(AbstractTests.TestMultiply):
 	# Tests constant evaluation of the less than or equal to operator
 	source_path = "misc/const-ge.hc"
+	factor = 3
 
 class TestUnaryMinus(AbstractTests.TestValidProgram):
 	source_path = "misc/unary-minus.hc"
@@ -219,23 +221,11 @@ class TestLogicalOr(AbstractTests.TestValidProgram):
 			 [ 10,   5,   8, 13,  10,   9,  3,  10]),
 		])
 
-class TestConstOr(AbstractTests.TestValidProgram):
-	source_path = "misc/const-or.hc"
-	floor_size = 16
-
+class TestConstOr(AbstractTests.TestMultiply):
 	# This file tests static evaluation of the logical or operator.
 	# It should output each value in the input multiplied by 10.
-	def test_output(self):
-		self.run_tests([
-			([], []),
-			([ 11], [110]),
-			([  7, -4], [70, -40]),
-			([ 11,  9, -3], [110, 90, -30]),
-			([-13,  7,  1, -1], [-130, 70, 10, -10]),
-			([ 16,  4, 18, -6, 5], [160, 40, 180, -60, 50]),
-			([ 12,  1, -2, -7, 3, 2], [120, 10, -20, -70, 30, 20]),
-			([  0,  0,  0,  0], [0, 0, 0, 0]),
-		])
+	source_path = "misc/const-or.hc"
+	factor = 10
 
 class TestLogicalXor(AbstractTests.TestValidProgram):
 	source_path = "misc/logical-xor.hc"
@@ -287,3 +277,7 @@ class TestLogicalXnor(AbstractTests.TestValidProgram):
 			([  0,   0,  -7,  0,   0,  -3, -5, -11],
 			 [  0,   0,                    -5, -11]),
 		])
+
+class TestConstXor(AbstractTests.TestMultiply):
+	source_path = "misc/const-xor.hc"
+	factor = 2

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -236,3 +236,27 @@ class TestConstOr(AbstractTests.TestValidProgram):
 			([ 12,  1, -2, -7, 3, 2], [120, 10, -20, -70, 30, 20]),
 			([  0,  0,  0,  0], [0, 0, 0, 0]),
 		])
+
+class TestLogicalXor(AbstractTests.TestValidProgram):
+	source_path = "misc/logical-xor.hc"
+	floor_size = 16
+
+	# This file tests use of the not equals operator as logical xor.
+	# The file should read pairs of values from the inbox, then output them both
+	# only if exactly one is positive.
+	def test_output(self):
+		self.run_tests([
+			([], []),
+			([  1, -11], [1, -11]),
+			([ -2,  11,  -7,  7], [-2, 11, -7, 7]),
+			([  3,  -4,   2, 13,  -9, -14], [3, -4]),
+			([-12,  11, -11, -1,  14, -14, -8,   7],
+			 [-12,  11,           14, -14, -8,   7]),
+			([ -3,  -9,  13, -3, -13,  10, -4, -21],
+			 [           13, -3, -13,  10]),
+			([  7,   0,   0,  5,   1,  17,  1, -12],
+			 [  7,   0,   0,  5,            1, -12]),
+			([  0,   0,   6,  0,   4,   0,  3,  10],
+			 [            6,  0,   4,   0]),
+			([ 10,   5,   8, 13,  10,   9,  3,  10], []),
+		])


### PR DESCRIPTION
Allow `!=` and `==` to work as xor and xnor respectively, when given boolean type arguments.